### PR TITLE
Allow < 1 FPS

### DIFF
--- a/StraatScan/Managers/DetectionManager.swift
+++ b/StraatScan/Managers/DetectionManager.swift
@@ -75,6 +75,18 @@ class DetectionManager: NSObject, ObservableObject, VideoCaptureDelegate {
 
     private var detectionTimer: Timer?
     
+    /// The time interval between processed frames.
+    private var lastFrameTime: TimeInterval = 0
+    
+    /// The frame rate being used to process frames by the model.
+    private lazy var frameRateFPS: Double = {
+        if let s = Bundle.main.object(forInfoDictionaryKey: "FrameRateFPS") as? String,
+           let v = Double(s) {
+            return v
+        }
+        return Bundle.main.object(forInfoDictionaryKey: "FrameRateFPS") as? Double ?? 2.0
+    }()
+    
     // MARK: - Initialization
     
     /// Initializes the DetectionManager, loading the YOLO model and setting up video capture.
@@ -234,6 +246,12 @@ class DetectionManager: NSObject, ObservableObject, VideoCaptureDelegate {
     ///   - capture: The video capture instance.
     ///   - sampleBuffer: The captured video frame.
     func videoCapture(_ capture: VideoCapture, didCaptureVideoFrame sampleBuffer: CMSampleBuffer) {
+        // compute minimum seconds between frames and skip if too fast.
+        let now = Date().timeIntervalSince1970
+        let interval = 1.0 / frameRateFPS
+        guard now - lastFrameTime >= interval else { return }
+        lastFrameTime = now
+        
         // Only process if no other frame is currently being processed.
         if currentBuffer == nil, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
            let request = visionRequest {

--- a/StraatScan/Managers/VideoCapture.swift
+++ b/StraatScan/Managers/VideoCapture.swift
@@ -119,14 +119,6 @@ public class VideoCapture: NSObject {
 
         do {
             try captureDevice.lockForConfiguration()
-
-            // Set frame rate via Info.plist (key: FrameRateFPS)
-            let frameRateFPS = (Bundle.main.object(forInfoDictionaryKey: "FrameRateFPS") as? String)
-                .flatMap(Int.init) ?? 2
-            let desiredFrameDuration = CMTime(value: 1, timescale: CMTimeScale(frameRateFPS))
-            captureDevice.activeVideoMaxFrameDuration = desiredFrameDuration
-            captureDevice.activeVideoMinFrameDuration = desiredFrameDuration
-
             captureDevice.focusMode = .continuousAutoFocus
             captureDevice.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
             captureDevice.exposureMode = .continuousAutoExposure


### PR DESCRIPTION
- Ensure that it is possible to process frames under 1 FPS. This was not possible with the current implementation, but is necessary if you move past objects quickly that would be missed with FPS > 1.